### PR TITLE
Explictly require benchden

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ devtools::install_github("hafen/ed")
 To recreate the plot above:
 
 ```r
+require(benchden)
 ed_plot(~ x | density, data = benchden,
   scales = list(relation = "free", draw = FALSE),
   panel = function(x, y, ..., subscripts) {


### PR DESCRIPTION
To the uninitiated user (perhaps like myself), it may not be clear that `benchden` is a package since it's also the name of the dataset.

Also, #1 
